### PR TITLE
added validity check for named DNAStringSets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeFeatures
 Title: What the Package Does (one line, title case)
-Version: 0.0.0.9001
+Version: 0.0.0.9002
 Authors@R: person("First", "Last", , "first.last@example.com", role = c("aut", "cre"))
 Description: What the package does (one paragraph)
 Depends: 

--- a/R/metagenomeAnnotation-class.R
+++ b/R/metagenomeAnnotation-class.R
@@ -53,6 +53,8 @@ setValidity("metagenomeAnnotation", function(object) {
     msg <- NULL
     if(!("featureData" %in% ls(object)) || !is(object@featureData, "DNAStringSet"))
         msg <- paste(msg, "'featureData' slot must contain a DNAStringSeq object with sequence data", sep = "\n")
+    if(is.null(names(object@featureData)))
+        msg <- paste(msg, "'featureData' slot must contain a named DNAStringSet object",sep="\n")
     if(!("mgAnnotatedDF" %in% ls(object)) || !is(object@mgAnnotatedDF, "AnnotatedDataFrame"))
         msg <- paste(msg, "'taxa' slot must contain a tbl_sqlite object with taxonomy data", sep = "\n")
     if(!("metadata" %in% ls(.self)) || !is(.self@metadata, "list"))


### PR DESCRIPTION
While it appears that readDNAStringSet automatically names sequences I'm not sure if (for example, like I did) things might potentially break if it's not named? This adds a requirement that DNAStringSets are named.

This is a suggestion per issue #1. Do you think this is useful?